### PR TITLE
Added Node.js web server for easier local testing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
 # Welcome to Glyphr Studio!
-Glyphr Studio is a free, web based font editor, focusing on font design hobbyists.  
+Glyphr Studio is a free, web based font editor, focusing on font design hobbyists.
 More information can be found at [glyphrstudio.com](http://glyphrstudio.com) - and/or follow [@glyphrstudio](https://twitter.com/glyphrstudio) on twitter.
 
 ## State of the Repo
 Beta 4 is under development now.  Please check the [Beta 4 Milestone Issue List](https://github.com/mattlag/GLYPHR/issues?milestone=3&state=open) to see what features are being developed, and what issues are being addressed.
-[Beta 3.1](https://github.com/mattlag/GLYPHR/releases/tag/v0.3.1.dev) is the current stable release, and is the build that is currently hosted at [http://glyphrstudio.com](http://glyphrstudio.com).  
+[Beta 3.1](https://github.com/mattlag/GLYPHR/releases/tag/v0.3.1.dev) is the current stable release, and is the build that is currently hosted at [http://glyphrstudio.com](http://glyphrstudio.com).
 
 ## Contributing & Feedback
 I'm an interaction designer by trade, and have decided to use Glyphr Studio as a giant crash course in JavaScript and HTML5.  Since this is my first major HTML5/JS app, there are many opportunities for growth & improvement - for both code, and collaborative development styles.
 If you’d like to contribute a feature or bug fix, please make sure to search the issue tracker first, your issue may have already been discussed or fixed in master.  After researching, please feel free to fork and send a pull request.
+
+## Running the App
+Modern browsers usually won't allow you to run Javascript from your local machine without a web server. To run the app, either serve the 'app' folder of this repo up with your web server or
+
+* Install node.js
+* Run 'node server.js' from within the root project directory to start the app
+* Go to [http://localhost:3000](http://localhost:3000)
+
 
 ## License
 Copyright (C) 2014 Matthew LaGrandeur, released under [GPL 3.0](https://github.com/mattlag/GLYPHR/blob/master/_LICENSE-gpl-3.0.txt)

--- a/server.js
+++ b/server.js
@@ -1,0 +1,66 @@
+var http = require('http'),
+    path = require('path'),
+    fs = require('fs');
+
+http.createServer(function(req, res){
+    var root = "app",
+        url = "",
+        contentType = "text/html",
+        filePath = "",
+        rootFile = "glyphr.html",
+        stream,
+        mimeTypes = {
+            '.txt': 'text/plain',
+            '.html': 'text/html',
+            '.css': 'text/css',
+            '.xml': 'application/xml',
+            '.json': 'application/json',
+            '.js': 'application/javascript',
+            '.jpg': 'image/jpeg',
+            '.jpeg': 'image/jpeg',
+            '.gif': 'image/gif',
+            '.png': 'image/png',
+            '.svg': 'image/svg+xml'
+        };
+
+    if (req.method !== 'GET') {
+        res.writeHead(405);
+        res.end('Unsupported request method', 'utf8');
+        return;
+    }
+
+    if ('.' + req.url !== './') {
+        filePath = root + req.url;
+    } else {
+        filePath = root + '/' + rootFile;
+    }
+
+    fs.exists(filePath, function(file) {
+        if (file === false) {
+            res.writeHead(404);
+            res.end();
+            return;
+        }
+
+        stream = fs.createReadStream(filePath);
+
+        stream.on('error', function(error) {
+            res.writeHead(500);
+            res.end();
+            return;
+        });
+
+        contentType = mimeTypes[path.extname(filePath)];
+
+        res.setHeader('Content-Type', contentType);
+        res.writeHead(200);
+
+        stream.pipe(res);
+        stream.on('end', function() {
+            res.end();
+        });
+    });
+
+}).listen(3000);
+
+console.log('Server running at http://localhost:3000/');


### PR DESCRIPTION
Because modern web browsers won't allow Javascript that's on the local machine to be executed, a web server is required to run a copy cloned to the local machine. This usually involves installing and configuring something like apache or nginx.

As Node.js is increasingly being used for web development tools, there's a likelihood that Node.js will be installed on the system. In this case, we can use a web server written in Node.js like the one in this pull request.
