### PR TITLE
clicking to toolsarea rapidly causes selection of half the interface

### DIFF
--- a/app/glyphr.css
+++ b/app/glyphr.css
@@ -602,6 +602,10 @@
 		left:500px;
 		top:10px;
 		z-index:10;
+		-moz-user-select:none;
+		-webkit-user-select:none;
+		-ms-user-select:none;
+		user-select:none;
 	}
 
 	#toolsarea div {


### PR DESCRIPTION
Since its not useful to select anything in this area, selecting should be blocked here.
