### PR TITLE
Accept svg file content sent by postMessage

### DIFF
--- a/dev/js/page_firstrun.js
+++ b/dev/js/page_firstrun.js
@@ -22,6 +22,7 @@
 		document.getElementById("firstruntableleft").addEventListener('dragover', handleDragOver, false);
 		document.getElementById("firstruntableleft").addEventListener('drop', handleDrop, false);
 		document.getElementById("firstruntableleft").addEventListener('dragleave', handleDragLeave, false);
+		window.addEventListener('message', handleMessage, false);
 
 
 		document.getElementById('splashscreenlogo').innerHTML = makeGlyphrStudioLogo({'fill':'white', 'width':400});
@@ -80,6 +81,11 @@
 
 		reader.readAsText(f);
 
+	}
+
+	function handleMessage(evt) {
+		_UI.droppedFileContent = evt.data;
+		ioSVG_importSVGfont(false);
 	}
 
 	function handleDragOver(evt) {


### PR DESCRIPTION
Hi Matt,

We're following your project closely and are really excited about the upcoming svg import/export features.
Today I tried it with an svg file produced by Prototypo, I noticed some bugs in the outlines but I wanted to know how hard it would be to make it possible to open a Prototypo font directly in Glyphr Studio, with a single click.
And it was surprisingly easy! The change is only 4 lines of code for Glyphr.

I know svg isn't the best interchange format for fonts but it's already a good start. Let us know what you think and let's keep in touch.

Cheers,
Louis-Rémi

![prototypo glyphr](https://cloud.githubusercontent.com/assets/39374/4977787/7d7eb466-68ea-11e4-8759-82ea7a435e00.png)
