### PR TITLE
Let the opener know when Glyphr is ready to accept svg messages

### DIFF
--- a/dev/js/page_firstrun.js
+++ b/dev/js/page_firstrun.js
@@ -23,6 +23,9 @@
 		document.getElementById("firstruntableleft").addEventListener('drop', handleDrop, false);
 		document.getElementById("firstruntableleft").addEventListener('dragleave', handleDragLeave, false);
 		window.addEventListener('message', handleMessage, false);
+		if ( window.opener ) {
+			window.opener.postMessage('ready', '*');
+		}
 
 
 		document.getElementById('splashscreenlogo').innerHTML = makeGlyphrStudioLogo({'fill':'white', 'width':400});


### PR DESCRIPTION
Previously we were using an arbitrary setTimeout before trying to send the svg message to Glyphr. 
This wasn't very reliable.
